### PR TITLE
Added missing embedded Dockerfile

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,13 +23,13 @@ jobs:
           - tox_env: lint
           # - tox_env: docs
           - tox_env: py36
-            PREFIX: PYTEST_REQPASS=2
+            PREFIX: PYTEST_REQPASS=3
           - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=2
+            PREFIX: PYTEST_REQPASS=3
           - tox_env: py37
-            PREFIX: PYTEST_REQPASS=2
+            PREFIX: PYTEST_REQPASS=3
           - tox_env: py38
-            PREFIX: PYTEST_REQPASS=2
+            PREFIX: PYTEST_REQPASS=3
           - tox_env: packaging
 
     steps:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+"""Pytest Config."""
+
+pytest_plugins = ["helpers_namespace"]

--- a/molecule_docker/playbooks/Dockerfile.j2
+++ b/molecule_docker/playbooks/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -32,15 +32,13 @@
       register: dockerfile_stats
 
     - name: Create Dockerfiles from image names
-      vars:
-        # TODO(ssbarnea): expose module dir so it can also be used by plugins
-        molecule_module_directory: "{{ playbook_dir + '/../../../..' }}"
       template:
+        # when using embedded playbooks the dockerfile is alonside them
         src: >-
           {%- if dockerfile_stats.results[i].stat.exists -%}
           {{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}
           {%- else -%}
-          {{ molecule_module_directory + '/data/Dockerfile.j2' }}
+          {{ playbook_dir + '/Dockerfile.j2' }}
           {%- endif -%}
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
         mode: "0600"

--- a/molecule_docker/playbooks/validate-dockerfile.yml
+++ b/molecule_docker/playbooks/validate-dockerfile.yml
@@ -1,0 +1,63 @@
+#!/usr/bin/env ansible-playbook
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    platforms:
+      # platforms supported as being managed by molecule/ansible, this does
+      # not mean molecule itself can run on them.
+      - image: alpine:edge
+      - image: centos:7
+      - image: centos:8
+      - image: ubuntu:latest
+      - image: debian:latest
+  tasks:
+
+    - name: Assure we have docker module installed
+      pip:
+        name: docker
+
+    - name: create temporary dockerfiles
+      tempfile:
+        prefix: "molecule-dockerfile-{{ item.image }}"
+        suffix: build
+      register: temp_dockerfiles
+      with_items: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.image }}"
+
+    - name: expand Dockerfile templates
+      template:
+        src: Dockerfile.j2
+        dest: "{{ temp_dockerfiles.results[index].path }}"
+      register: result
+      with_items: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.image }}"
+
+    - name: Test Dockerfile template
+      docker_image:
+        name: "{{ item.item.image }}"
+        build:
+          path: "."
+          dockerfile: "{{ item.dest }}"
+          pull: true
+          nocache: true
+        source: build
+        state: present
+        debug: true
+        force_source: true
+      with_items: "{{ result.results }}"
+      loop_control:
+        label: "{{ item.item.image }}"
+      register: result
+
+    - name: Clean up temporary Dockerfile's
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ temp_dockerfiles.results | map(attribute='path') | list }}"
+
+    - debug: var=result

--- a/molecule_docker/test/test_func.py
+++ b/molecule_docker/test/test_func.py
@@ -1,12 +1,24 @@
 """Functional tests."""
 import os
+import subprocess
 
 import pytest
 import sh
 from molecule import logger
 from molecule.test.conftest import change_dir_to, run_command
 
+import molecule_docker
+
 LOG = logger.get_logger(__name__)
+
+
+def format_result(result: subprocess.CompletedProcess):
+    """Return friendly representation of completed process run."""
+    return (
+        f"RC: {result.returncode}\n"
+        + f"STDOUT: {result.stdout}\n"
+        + f"STDERR: {result.stderr}"
+    )
 
 
 # @pytest.mark.xfail(reason="need to fix template path")
@@ -28,3 +40,36 @@ def test_command_init_scenario(temp_dir, DRIVER):
 
         cmd = sh.molecule.bake("--debug", "test", "-s", "test-scenario")
         run_command(cmd)
+
+
+def test_dockerfile():
+    """Verify that our embedded dockerfile can be build."""
+    result = subprocess.run(
+        ["ansible-playbook", "--version"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        shell=False,
+        universal_newlines=True,
+    )
+    assert result.returncode == 0, result
+    assert "ansible-playbook" in result.stdout
+
+    module_path = os.path.dirname(molecule_docker.__file__)
+    assert os.path.isdir(module_path)
+    env = os.environ.copy()
+    env["ANSIBLE_FORCE_COLOR"] = "0"
+    result = subprocess.run(
+        ["ansible-playbook", "-i", "localhost,", "playbooks/validate-dockerfile.yml"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        shell=False,
+        cwd=module_path,
+        universal_newlines=True,
+        env=env,
+    )
+    assert result.returncode == 0, format_result(result)
+    # , result

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ lint =
     pre-commit >= 1.21.0
 test =
     molecule[test]
+    pytest-helpers-namespace
 
 [options.entry_points]
 molecule.driver =

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ setenv =
     MOLECULE_NO_LOG=0
 deps =
     devel: ansible>=2.10.0a2,<2.11
+    py{36,37,38}: molecule[test]
     py{36,37,38}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
     dockerfile: ansible>=2.9.12
     selinux

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for preventing changes that may break pytest collection
-    sh -c "PYTEST_ADDOPTS= python -m pytest -p no:cov --collect-only 2>&1 >{envlogdir}/collect.log"
+    python -m pytest -p no:cov --collect-only
     python -m pytest {posargs:-l}
 
 whitelist_externals =


### PR DESCRIPTION
Fixes regression that happened when we moved driver outside molecule core. Scenarios not using pre-build image option and missing a custom Dockerfile were affected by this bug.