### PR TITLE
Make tests compatible with molecule 3.2

### DIFF
--- a/molecule_docker/test/test_func.py
+++ b/molecule_docker/test/test_func.py
@@ -3,8 +3,7 @@ import os
 import subprocess
 
 import pytest
-import sh
-from molecule import logger
+from molecule import logger, util
 from molecule.test.conftest import change_dir_to, run_command
 
 import molecule_docker
@@ -25,20 +24,25 @@ def format_result(result: subprocess.CompletedProcess):
 def test_command_init_scenario(temp_dir, DRIVER):
     """Verify that init scenario works."""
     role_directory = os.path.join(temp_dir.strpath, "test-init")
-    options = {}
-    cmd = sh.molecule.bake("init", "role", "test-init", **options)
+    cmd = ["molecule", "init", "role", "test-init"]
     run_command(cmd)
 
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, "test-scenario")
         options = {"role_name": "test-init", "driver-name": DRIVER}
-        cmd = sh.molecule.bake("init", "scenario", "test-scenario", **options)
+        cmd = [
+            "molecule",
+            "init",
+            "scenario",
+            "test-scenario",
+            *util.dict2args(options),
+        ]
         run_command(cmd)
 
         assert os.path.isdir(scenario_directory)
 
-        cmd = sh.molecule.bake("--debug", "test", "-s", "test-scenario")
+        cmd = ["molecule", "--debug", "test", "-s", "test-scenario"]
         run_command(cmd)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.0.2
+    molecule >= 3.2.0a0
     # selinux python module is needed as least by ansible-docker modules
     # and allows us of isolated (default) virtualenvs. It does not avoid need
     # to install the system selinux libraries but it will provide a clear


### PR DESCRIPTION
Marked as major because it will require a major version bump due to bumped dependency.

Related: https://github.com/ansible-community/molecule/pull/2917