### PR TITLE
Disable broken pip 2020-resolver

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,9 @@ setenv =
     ANSIBLE_VERBOSITY=1
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
+    # Disabled new resolved due to https://github.com/pypa/pip/issues/8713
     # new resolve a must or test extras will not install right
-    PIP_USE_FEATURE=2020-resolver
+    # PIP_USE_FEATURE=2020-resolver
     MOLECULE_NO_LOG=0
 deps =
     devel: ansible>=2.10.0a2,<2.11


### PR DESCRIPTION
Apparently the 2020-resolver is not reliable and causes endless loops during install.

Related: https://github.com/pypa/pip/issues/8713