### PR TITLE
Cleanup output, use `loop` over `with_items`.

### DIFF
--- a/molecule_docker/playbooks/destroy.yml
+++ b/molecule_docker/playbooks/destroy.yml
@@ -18,7 +18,7 @@
         keep_volumes: "{{ item.keep_volumes | default(true) }}"
         container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"
       no_log: false
@@ -31,12 +31,14 @@
       register: docker_jobs
       until: docker_jobs.finished
       retries: 300
-      with_items: "{{ server.results }}"
+      loop: "{{ server.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
 
     - name: Delete docker network(s)
       action: docker_network
       args: "{{ item }}"
-      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks('absent') }}"
+      loop: "{{ molecule_yml.platforms | molecule_get_docker_networks('absent') }}"
       loop_control:
         label: "{{ item.name }}"
       no_log: false


### PR DESCRIPTION
I noticed `molecule destroy` show quite some information:

```
TASK [Wait for instance(s) deletion to complete] *******************************
FAILED - RETRYING: Wait for instance(s) deletion to complete (300 retries left).
changed: [localhost] => (item={'started': 1, 'finished': 0, 'ansible_job_id': '333564963040.96040', 'results_file': '/home/robertdb/.ansible_async/333564963040.96040', 'changed': True, 'failed': False, 'item': {'command': '/sbin/init', 'image': 'robertdebock/fedora:rawhide', 'name': 'xinetd-fedora-rawhide', 'pre_build_image': True, 'privileged': True, 'volumes': ['/sys/fs/cgroup:/sys/fs/cgroup:ro']}, 'ansible_loop_var': 'item'})
```

This change reduces that ouput to:

```
TASK [Wait for instance(s) deletion to complete] *******************************
FAILED - RETRYING: Wait for instance(s) deletion to complete (300 retries left).
ok: [localhost] => (item=xinetd-fedora-rawhide)
```

Hope that helps to clean the output a little more.