### PR TITLE
Pass stop_signal and kill_signal to docker_container in create.yml

### DIFF
--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -176,6 +176,8 @@
         tty: "{{ item.tty | default(omit) }}"
         labels: "{{ molecule_labels | combine(item.labels | default({})) }}"
         container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
+        stop_signal: "{{ item.stop_signal | default(omit) }}"
+        kill_signal: "{{ item.kill_signal | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       loop_control:


### PR DESCRIPTION
This is useful when using `command: /sbin/init`.

```
platforms:
  - name: instance
    command: /sbin/init
    stop_signal: RTMIN+3
```

Seee also https://bugzilla.redhat.com/show_bug.cgi?id=1201657