### PR TITLE
Fix condition when path is missing

### DIFF
--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -53,7 +53,9 @@
         src: "{{ molecule_scenario_directory }}/"
         dest: "{{ molecule_ephemeral_directory }}"
         mode: "0600"
-      when: not item.pre_build_image | default(false) and not item.path
+      when:
+        - not item.pre_build_image | default(false)
+        - not (item.path | default(false))
       loop: "{{ molecule_yml.platforms }}"
 
     - name: Discover local Docker images


### PR DESCRIPTION
Fix bug introduced by #51 where ansible would choke when path is not specified and pre_build_image is false.