### PR TITLE
fix: specify docker modules namespace

### DIFF
--- a/molecule_docker/driver.py
+++ b/molecule_docker/driver.py
@@ -218,7 +218,7 @@ class Docker(Driver):
         return {"instance": instance_name}
 
     def ansible_connection_options(self, instance_name):
-        x = {"ansible_connection": "docker"}
+        x = {"ansible_connection": "community.docker.docker"}
         if "DOCKER_HOST" in os.environ:
             x["ansible_docker_extra_args"] = "-H={}".format(os.environ["DOCKER_HOST"])
         return x

--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -7,6 +7,8 @@
   vars:
     molecule_labels:
       owner: molecule
+  collections:
+    - community.docker
   tasks:
     - name: Log into a Docker registry
       docker_login:

--- a/molecule_docker/playbooks/destroy.yml
+++ b/molecule_docker/playbooks/destroy.yml
@@ -4,6 +4,8 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.docker
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/molecule_docker/playbooks/validate-dockerfile.yml
+++ b/molecule_docker/playbooks/validate-dockerfile.yml
@@ -3,6 +3,8 @@
 - hosts: localhost
   connection: local
   gather_facts: false
+  collections:
+    - community.docker
   vars:
     platforms:
       # platforms supported as being managed by molecule/ansible, this does


### PR DESCRIPTION
Running in an ansible-core project, I get this failure while running a molecule test with the docker driver:

```
INFO     Running default > destroy
ERROR! couldn't resolve module/action 'docker_container'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/var/home/yajo/mydevel/mando/.venv/lib/python3.9/site-packages/molecule_docker/playbooks/destroy.yml': line 8, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - name: Destroy molecule instance(s)
      ^ here
```

After fixing the playbooks, it still fails with:

```
PLAY [prepare] *****************************************************************

TASK [Gathering Facts] *********************************************************
fatal: [basic]: FAILED! => {"msg": "the connection plugin 'docker' was not found"}
```

So, here are the fixes.