### PR TITLE
Rely on community.docker collection

### DIFF
--- a/.ansible.cfg
+++ b/.ansible.cfg
@@ -1,1 +1,0 @@
-# Used for testing to avoid using one from outside repository

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,34 +16,39 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.tox_env }}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - tox_env: lint
+          - name: lint
+            tox_env: lint
+          - name: dockerfile
+            tox_env: dockerfile
           # - tox_env: docs
-          - tox_env: py36
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py37
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py38
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py39
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py39-devel
-            PREFIX: PYTEST_REQPASS=3
+          - name: py36
+            tox_env: py36-2.9,py36-2.10,py36-2.11
+            PREFIX: PYTEST_REQPASS=2
+          - name: py37
+            tox_env: py37-2.9,py37-2.10,py37-2.11
+            PREFIX: PYTEST_REQPASS=2
+          - name: py38
+            tox_env: py38-2.9,py38-2.10,py38-2.11
+            PREFIX: PYTEST_REQPASS=2
+          - name: py39
+            tox_env: py39-2.9,py39-2.10,py39-2.11
+            PREFIX: PYTEST_REQPASS=2
           - tox_env: packaging
 
     steps:
       - uses: actions/checkout@v1
       - name: Install system dependencies
+        # community.docker requires docker>=5.0.0 but ubuntu has older
         run: |
           sudo apt-get update \
-          && sudo apt-get install -y  ansible \
+          && sudo apt-get install -y ansible python3-docker python3-requests \
+          && sudo pip3 install -U docker \
           && ansible-doc -l | grep docker_container
       - name: Find python version
         id: py_ver

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -40,6 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update \
+          && sudo apt-get install -y  ansible \
+          && ansible-doc -l | grep docker_container
       - name: Find python version
         id: py_ver
         shell: python

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,15 @@ provisioning test resources.
 
 Please note that this driver is currently in its early stage of development.
 
+This plugin will function only if you also install `community.docker` ansible
+collection. Keep in mind that this requires newer version of docker python
+module which may not come with system-packaged versions of ansible like
+Ubuntu ones.
+
+Please do not file bugs towards molecule or this plugin if Ansible fails to
+execute any docker modules (missing or incorrect versions of docker or requests
+python modules). Instead file them on [community.docker](https://github.com/ansible-collections/community.docker)
+
 .. _get-involved:
 
 Get Involved

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+# Used for testing to avoid using one from outside repository
+[defaults]
+# https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html
+interpreter_python = auto
+callback_enabled = community.general.yaml

--- a/molecule_docker/driver.py
+++ b/molecule_docker/driver.py
@@ -217,7 +217,7 @@ class Docker(Driver):
         return {"instance": instance_name}
 
     def ansible_connection_options(self, instance_name):
-        x = {"ansible_connection": "docker"}
+        x = {"ansible_connection": "community.docker.docker"}
         if "DOCKER_HOST" in os.environ:
             x["ansible_docker_extra_args"] = "-H={}".format(os.environ["DOCKER_HOST"])
         return x

--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -4,6 +4,8 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.docker
   vars:
     molecule_labels:
       owner: molecule

--- a/molecule_docker/playbooks/destroy.yml
+++ b/molecule_docker/playbooks/destroy.yml
@@ -4,6 +4,8 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.docker
   tasks:
     - name: Destroy molecule instance(s)
       docker_container:

--- a/molecule_docker/test/test_func.py
+++ b/molecule_docker/test/test_func.py
@@ -7,8 +7,6 @@ from molecule import logger, util
 from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
-import molecule_docker
-
 LOG = logger.get_logger(__name__)
 
 
@@ -21,18 +19,17 @@ def format_result(result: subprocess.CompletedProcess):
     )
 
 
-# @pytest.mark.xfail(reason="need to fix template path")
-def test_command_init_scenario(temp_dir, DRIVER):
+def test_command_init_and_test_scenario(temp_dir, DRIVER):
     """Verify that init scenario works."""
-    role_directory = os.path.join(temp_dir.strpath, "test-init")
-    cmd = ["molecule", "init", "role", "test-init"]
+    role_directory = os.path.join(temp_dir.strpath, "test_init")
+    cmd = ["molecule", "init", "role", "test_init"]
     result = run_command(cmd)
     assert result.returncode == 0
 
     with change_dir_to(role_directory):
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, "test-scenario")
-        options = {"role_name": "test-init", "driver-name": DRIVER}
+        options = {"role-name": "test_init", "driver-name": DRIVER}
         cmd = [
             "molecule",
             "init",
@@ -48,36 +45,3 @@ def test_command_init_scenario(temp_dir, DRIVER):
         cmd = ["molecule", "--debug", "test", "-s", "test-scenario"]
         result = run_command(cmd)
         assert result.returncode == 0
-
-
-def test_dockerfile():
-    """Verify that our embedded dockerfile can be build."""
-    result = subprocess.run(
-        ["ansible-playbook", "--version"],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.DEVNULL,
-        shell=False,
-        universal_newlines=True,
-    )
-    assert result.returncode == 0, result
-    assert "ansible-playbook" in result.stdout
-
-    module_path = os.path.dirname(molecule_docker.__file__)
-    assert os.path.isdir(module_path)
-    env = os.environ.copy()
-    env["ANSIBLE_FORCE_COLOR"] = "0"
-    result = subprocess.run(
-        ["ansible-playbook", "-i", "localhost,", "playbooks/validate-dockerfile.yml"],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.DEVNULL,
-        shell=False,
-        cwd=module_path,
-        universal_newlines=True,
-        env=env,
-    )
-    assert result.returncode == 0, format_result(result)
-    # , result

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
     selinux; sys_platform=="linux2"
     selinux; sys_platform=="linux"
     docker >= 4.3.1
+    requests  # also required by docker
 
 [options.extras_require]
 docs =

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ setenv =
     MOLECULE_NO_LOG=0
 deps =
     devel: ansible>=2.10.0a2,<2.11
-    py{36,37,38}: molecule[test]
-    py{36,37,38}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{36,37,38,39}: molecule[test]
+    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
     dockerfile: ansible>=2.9.12
     selinux
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@ envlist =
     lint
     docs
     packaging
-    py{36,37,38,39}
-    py{36,37,38,39}-{devel}
+    py{36,37,38,39}-2.9
+    py{36,37,38,39}-2.10
+    py{36,37,38,39}-2.11
+    py{36,37,38,39}-devel
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -25,8 +27,10 @@ passenv =
     SSH_AUTH_SOCK
     TERM
 setenv =
-    ANSIBLE_CONFIG={toxinidir}/dev/null
+    ANSIBLE_CONFIG={toxinidir}/ansible.cfg
     ANSIBLE_CALLABLE_WHITELIST={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
+    ANSIBLE_CALLABLE_ENABLED={env:ANSIBLE_CALLABLE_WHITELIST:timer,profile_roles}
+    ANSIBLE_NOCOWS=1
     ANSIBLE_DISPLAY_FAILED_STDERR=1
     ANSIBLE_VERBOSITY=1
     PYTHONDONTWRITEBYTECODE=1
@@ -36,23 +40,26 @@ setenv =
     # PIP_USE_FEATURE=2020-resolver
     MOLECULE_NO_LOG=0
 deps =
-    devel: ansible>=2.10.0a2,<2.11
+    devel: ansible-core>=2.11.1,<2.12
     py{36,37,38,39}: molecule[test]
+    py{36,37,38,39}-2.9: ansible>=2.9.22,<2.10
+    py{36,37,38,39}-2.10: ansible-base>=2.10,<2.11
+    py{36,37,38,39}-2.11: ansible-core>=2.11.1,<2.12
     py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
-    dockerfile: ansible>=2.9.12
+    dockerfile: ansible-core>=2.11.1
     selinux
 extras =
     lint
     test
 commands =
-    ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
+    ansible-galaxy collection install community.docker
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for preventing changes that may break pytest collection
     python -m pytest -p no:cov --collect-only
     python -m pytest {posargs:-l}
 
-whitelist_externals =
+allowlist_externals =
     find
     rm
     sh
@@ -99,6 +106,25 @@ deps =
     sphinx-autobuild>=0.7.1,<1.0
 extras =
     docs
+
+[testenv:dockerfile]
+description = Tests ability to build ansible enabled container images (
+# This relies on system version of Ansible and does not install any
+# dependencies. That is by design as it allows us to test compatibility with
+# system ansible from Ubuntu, which is known to be very old.
+deps =
+skip_install = true
+usedevelop = false
+passenv = {[testenv]passenv}
+setenv = {[testenv]setenv}
+commands =
+    ansible --version
+    ansible-galaxy collection install community.docker
+    ansible-playbook -i localhost, molecule_docker/playbooks/validate-dockerfile.yml
+allowlist_externals =
+    ansible
+    ansible-galaxy
+    ansible-playbook
 
 [testenv:packaging]
 description =


### PR DESCRIPTION
* Stop using older docker modules and rely on `community.docker`. Still compatible with ansible 2.9-2.11, even with the core ansible versions but requires installation of `community.docker`, which must be done by the user.
* Document use of `community.docker`
* Refactor testing and include testing of all 3 supported versions of ansible