### PR TITLE
Enable ansible-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,13 +34,15 @@ repos:
           - flake8-black>=0.1.1
           - flake8-docstrings>=1.5.0
         language_version: python3
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v5.0.12
     hooks:
-      - id: yamllint
-        files: \.(yaml|yml)$
-        types: [file, yaml]
-        entry: yamllint --strict
+      - id: ansible-lint
+        always_run: true
+        pass_filenames: false
+        additional_dependencies:
+          - ansible>=2.9
+          - yamllint
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790
     hooks:

--- a/molecule_docker/playbooks/create.yml
+++ b/molecule_docker/playbooks/create.yml
@@ -26,6 +26,7 @@
         - item.registry is defined
         - item.registry.credentials is defined
         - item.registry.credentials.username is defined
+      no_log: true
 
     - name: Check presence of custom Dockerfiles
       stat:
@@ -63,7 +64,7 @@
         - not item.pre_build_image | default(false)
       register: docker_images
 
-    - name: Build an Ansible compatible image (new)
+    - name: Build an Ansible compatible image (new)  # noqa: no-handler
       when:
         - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
         - not item.item.pre_build_image | default(false)

--- a/molecule_docker/playbooks/validate-dockerfile.yml
+++ b/molecule_docker/playbooks/validate-dockerfile.yml
@@ -31,6 +31,7 @@
       template:
         src: Dockerfile.j2
         dest: "{{ temp_dockerfiles.results[index].path }}"
+        mode: 0600
       register: result
       with_items: "{{ platforms }}"
       loop_control:
@@ -58,6 +59,9 @@
       file:
         path: "{{ item }}"
         state: absent
+        mode: 0600
       loop: "{{ temp_dockerfiles.results | map(attribute='path') | list }}"
 
-    - debug: var=result
+    - name: Display results
+      debug:
+        var: result


### PR DESCRIPTION
Replace yamllint with ansible-lint, which also includes yamllint.
This is also fixing newly reported issues.