### PR TITLE
fixed delete network task when option

### DIFF
--- a/src/molecule_docker/playbooks/tasks/delete_network.yml
+++ b/src/molecule_docker/playbooks/tasks/delete_network.yml
@@ -9,5 +9,5 @@
     state: "absent"
   when:
     - docker_netname.exists
-    - docker_netname.network.Labels.owner is not defined
+    - docker_netname.network.Labels.owner is defined
     - docker_netname.network.Labels.owner == 'molecule'


### PR DESCRIPTION
Fixed delete network task to check if owner label is defined and if so, delete the network if it's owned by molecule.
Fixes issue #96