### PR TITLE
Remove `galaxy install <fqcn>` commands from `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,6 @@ extras =
     lint
     test
 commands =
-    ansible-galaxy collection install community.docker
     # failsafe as pip may install incompatible dependencies
     pip check
     # failsafe for broken installation
@@ -121,7 +120,7 @@ passenv = {[testenv]passenv}
 setenv = {[testenv]setenv}
 commands =
     ansible --version
-    ansible-galaxy collection install community.docker
+    ansible-galaxy collection install -r requirements.yml
     ansible-playbook -i localhost, src/molecule_docker/playbooks/validate-dockerfile.yml
 allowlist_externals =
     ansible


### PR DESCRIPTION
- avoid calling galaxy install for unitest jobs because molecule
  itself should be able install missing dependency automatically
- configure dockerfile testing to reuse existing requirements.yml
  file
