### PR TITLE
Add platform to the Build an Ansible compatible image task

### DIFF
--- a/src/molecule_docker/playbooks/create.yml
+++ b/src/molecule_docker/playbooks/create.yml
@@ -73,6 +73,7 @@
           pull: "{{ item.item.pull | default(true) }}"
           network: "{{ item.item.network_mode | default(omit) }}"
           args: "{{ item.item.buildargs | default(omit) }}"
+          platform: "{{ item.item.platform | default(omit) }}"
         name: "molecule_local/{{ item.item.image }}"
         docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
         cacert_path: "{{ item.cacert_path | default((lookup('env', 'DOCKER_CERT_PATH') + '/ca.pem') if lookup('env', 'DOCKER_CERT_PATH') else omit) }}"


### PR DESCRIPTION
This enables setting the architecture when building a Molecule compatible container See #114 