### PR TITLE
Remove the explicit docker host configuration from inventory

### DIFF
--- a/src/molecule_docker/driver.py
+++ b/src/molecule_docker/driver.py
@@ -220,8 +220,6 @@ class Docker(Driver):
 
     def ansible_connection_options(self, instance_name):
         x = {"ansible_connection": "community.docker.docker"}
-        if "DOCKER_HOST" in os.environ:
-            x["ansible_docker_extra_args"] = f"-H={os.environ['DOCKER_HOST']}"
         return x
 
     @cache


### PR DESCRIPTION
This should make the driver usable for other docker replacements like podman where a `DOCKER_HOST` env variable is required but the `docker` binary has a different signature and flags. 

Fixes: #137