### PR TITLE
Drop python 3.6 and 3.7 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,12 +29,6 @@ jobs:
           - name: dockerfile
             tox_env: dockerfile
           # - tox_env: docs
-          - name: py36
-            tox_env: py36-2.9,py36-2.10,py36-2.11
-            PREFIX: PYTEST_REQPASS=3
-          - name: py37
-            tox_env: py37-2.9,py37-2.10,py37-2.11
-            PREFIX: PYTEST_REQPASS=3
           - name: py38
             tox_env: py38-2.9,py38-2.10,py38-2.11
             PREFIX: PYTEST_REQPASS=3

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 color_output = True
 error_summary = True
 disallow_untyped_calls=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,6 @@ classifiers =
     Operating System :: OS Independent
 
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
@@ -49,7 +47,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.6
+python_requires = >=3.8
 package_dir =
   = src
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist =
     lint
     docs
     packaging
-    py{36,37,38,39}-2.9
-    py{36,37,38,39}-2.10
-    py{36,37,38,39}-2.11
-    py{36,37,38,39}-devel
+    py{38,39}-2.9
+    py{38,39}-2.10
+    py{38,39}-2.11
+    py{38,39}-devel
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -41,11 +41,11 @@ setenv =
     MOLECULE_NO_LOG=0
 deps =
     devel: ansible-core>=2.11.1,<2.12
-    py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-2.9: ansible>=2.9.22,<2.10
-    py{36,37,38,39}-2.10: ansible-base>=2.10,<2.11
-    py{36,37,38,39}-2.11: ansible-core>=2.11.1,<2.12
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
+    py{38,39}: molecule[test]
+    py{38,39}-2.9: ansible>=2.9.22,<2.10
+    py{38,39}-2.10: ansible-base>=2.10,<2.11
+    py{38,39}-2.11: ansible-core>=2.11.1,<2.12
+    py{38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
     dockerfile: ansible-core>=2.11.1
     selinux
 extras =


### PR DESCRIPTION
Since https://github.com/ansible-community/molecule/pull/3436 molecule
doesn't support python < 3.8, so we drop support for python 3.6 and 3.7.