### PR TITLE
Add support for cgroupns_mode

### DIFF
--- a/src/molecule_docker/driver.py
+++ b/src/molecule_docker/driver.py
@@ -74,6 +74,7 @@ class Docker(Driver):
             privileged: True|False
             security_opts:
               - seccomp=unconfined
+            cgroupns_mode: host|private
             devices:
               - /dev/fuse:/dev/fuse:rwm
             volumes:
@@ -134,6 +135,12 @@ class Docker(Driver):
     .. note:: Do note that running containers in privileged mode is considerably
               less secure. For details, please reference `Docker Security
               Configuration`_
+
+    .. note:: On some systems (macOS) you might have to set ``cgroupns_mode`` to
+              ``host`` for `systemd` to work. See `Docker Desktop release
+              notes`_ for more information.
+
+    .. _`Docker Desktop release notes`: https://docs.docker.com/desktop/release-notes/#bug-fixes-and-minor-changes-19
 
     .. note:: With the environment variable ``DOCKER_HOST`` the user can bind
               Molecule to a different `Docker`_ socket than the default

--- a/src/molecule_docker/playbooks/create.yml
+++ b/src/molecule_docker/playbooks/create.yml
@@ -166,6 +166,7 @@
         container_default_behavior: "{{ item.container_default_behavior | default('compatibility' if ansible_version.full is version_compare('2.10', '>=') else omit) }}"
         stop_signal: "{{ item.stop_signal | default(omit) }}"
         kill_signal: "{{ item.kill_signal | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       loop_control:


### PR DESCRIPTION
This fixes systemd support in Debian >=11 containers.

Minimal platforms configuration in `molecule.yml`:

```
platforms:
  - name: instance
    image: debian:bullseye
    command: /lib/systemd/systemd
    privileged: true
    cgroupns_mode: private
```

Example `Dockerfile.j2`:

```
FROM debian:bullseye

ARG DEBIAN_FRONTEND=noninteractive

RUN apt-get update && apt-get install -y python3 sudo bash ca-certificates \
        iproute2 python3-apt aptitude
RUN apt-get update && apt-get install -y systemd; \
        systemctl mask getty@tty1.service; \
        systemctl mask systemd-timesyncd.service;
RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
    /etc/systemd/system/*.wants/* \
    /lib/systemd/system/local-fs.target.wants/* \
    /lib/systemd/system/sockets.target.wants/*udev* \
    /lib/systemd/system/sockets.target.wants/*initctl* \
    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
    /lib/systemd/system/systemd-update-utmp*
```