### PR TITLE
fix: make sure directory for async is correctly set

### DIFF
--- a/src/molecule_docker/playbooks/create.yml
+++ b/src/molecule_docker/playbooks/create.yml
@@ -10,8 +10,8 @@
   tasks:
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
-      when: (lookup('env','HOME'))
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME'))
 
     - name: Log into a Docker registry
       community.docker.docker_login:

--- a/src/molecule_docker/playbooks/create.yml
+++ b/src/molecule_docker/playbooks/create.yml
@@ -8,6 +8,11 @@
     molecule_labels:
       owner: molecule
   tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
+      when: (lookup('env','HOME'))
+
     - name: Log into a Docker registry
       community.docker.docker_login:
         username: "{{ item.registry.credentials.username }}"

--- a/src/molecule_docker/playbooks/destroy.yml
+++ b/src/molecule_docker/playbooks/destroy.yml
@@ -5,6 +5,11 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
+      when: (lookup('env','HOME'))
+
     - name: Destroy molecule instance(s)
       community.docker.docker_container:
         name: "{{ item.name }}"
@@ -34,7 +39,6 @@
       loop: "{{ server.results }}"
       loop_control:
         label: "{{ item.item.name }}"
-
 
     - name: Delete docker networks(s)
       include_tasks: tasks/delete_network.yml

--- a/src/molecule_docker/playbooks/destroy.yml
+++ b/src/molecule_docker/playbooks/destroy.yml
@@ -7,8 +7,8 @@
   tasks:
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env','HOME') }}/.ansible_async'"
-      when: (lookup('env','HOME'))
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME'))
 
     - name: Destroy molecule instance(s)
       community.docker.docker_container:


### PR DESCRIPTION
In certain cases where the home directory environment variable (`$HOME`) is set and it doesn't match the home directory in `/etc/passwd` the `async_status` task will fail with a message such as:

```
"results_file": "/home/runner/.ansible_async/25596
1675523.4961", "started": 1}, "msg": "could not find job", "results_file": "/root/.ansible_async/255961675523.4961"
```

This fixes that issue by setting the `HOME` environment variable as the `ansible_async_dir` variable that 'async_status' task accepts as a override.

I ran into this issue with the `creator-ee` container that is supposedly going to be fixed but I'm proposing this change as this issue could still occur in other containers/environments.

Related:
https://github.com/ansible/ansible-runner/issues/1024
https://github.com/ansible/creator-ee/issues/19
https://github.com/ansible/ansible-runner/pull/1027
https://github.com/ansible-community/molecule-docker/issues/139
https://github.com/ansible-community/molecule-podman/pull/139