### PR TITLE
Update build-system requirements for setuptools-scm to >= 7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
 [build-system]
 requires = [
-  "pip >= 19.3.1",
-  "setuptools >= 42",
-  "setuptools_scm[toml] >= 3.5.0",
-  "setuptools_scm_git_archive >= 1.1",
-  "wheel >= 0.33.6",
+  "setuptools >= 45",
+  "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Update build-system requirements for setuptools-scm to >= 7.0.0, which obsoletes setuptools-scm-git-archive.
Remove the use of wheel and pip in build-system, as they are not required for a PEP517 build environment, facilitating pypa/build and pypa/installer.